### PR TITLE
Update run API, add trajectory and log file writers

### DIFF
--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -167,23 +167,25 @@ class Simulation:
             if i % self.energy_write_freq == 0:
                 self.energies.append(self.energy)
                 self.temperatures.append(kT)
+                if len(self.energies) == 5000:
+                    self._update_log_file()
+                    self.energies.clear()
+                    self.temperatures.clear()
             if i % self.trajectory_write_freq == 0:
                 self.system_history.append(np.copy(self.system))
-
-            if len(self.energies) == 5000:
-                self._update_log_file()
-                self.energies.clear()
-                self.temperatures.clear()
-            if len(self.system_history) == 500:
-                self._update_trajectory()
-                self.system_history.clear()
-
+                if len(self.system_history) == 500:
+                    self._update_trajectory()
+                    #self.system_history.clear()
 
             self.timestep += 1
         end = time.time()
         self._tps.append(np.round(n_steps / (end - start), 3))
-        self._update_trajectory()
-        self._update_log_file()
+        #self._update_trajectory()
+        #self.system_history.clear()
+        #self._update_log_file()
+        #self.energies.clear()
+        #self.temperatures.clear()
+
 
     def visualize(self, frame_number=-1, save_path=None):
         """
@@ -212,27 +214,46 @@ class Simulation:
         np.savetxt(fname="system.txt", X=system_array)
 
     def _update_trajectory(self):
-        with gsd.hoomd.open("trajectory.gsd", "wb") as traj:
-            for sys in self.system_history:
-                snap = gsd.hoomd.Snapshot()
-                snap.particles.N = self.n_particles 
-                snap.configuration.box = np.array([self.L, self.L, self.L, 0, 0, 0])
-                snap.particles.types = ["A"]
-                coords = np.append(
-                        sys, np.zeros((sys.shape[0], 1)), axis=1
-                )
-                snap.particles.position = coords 
-                traj.append(snap)
+        if len(self.system_history) != 0:
+            if not os.path.isfile("trajectory.gsd"):
+                with gsd.hoomd.open("trajectory.gsd", "wb") as traj:
+                    for sys in self.system_history:
+                        snap = gsd.hoomd.Snapshot()
+                        snap.particles.N = self.n_particles 
+                        snap.configuration.box = np.array([self.L, self.L, self.L, 0, 0, 0])
+                        snap.particles.types = ["A"]
+                        coords = np.append(
+                                sys, np.zeros((sys.shape[0], 1)), axis=1
+                        )
+                        snap.particles.position = coords 
+                        traj.append(snap)
+            else:
+                last_traj = gsd.hoomd.open("trajectory.gsd", "rb")
+                snapshots = [i for i in last_traj]
+                with gsd.hoomd.open("trajectory.gsd", "wb") as traj:
+                    for sys in self.system_history:
+                        snap = gsd.hoomd.Snapshot()
+                        snap.particles.N = self.n_particles 
+                        snap.configuration.box = np.array([self.L, self.L, self.L, 0, 0, 0])
+                        snap.particles.types = ["A"]
+                        coords = np.append(
+                                sys, np.zeros((sys.shape[0], 1)), axis=1
+                        )
+                        snap.particles.position = coords 
+                        snapshots.append(snap)
+                    traj.extend(snapshots)
+                last_traj.close()
 
     def _update_log_file(self):
-        if not os.path.isfile("log.txt"):
-            with open("log.txt", "w") as file:
-                for e, t in zip(self.energies, self.temperatures):
-                    file.write(f"{e},{t}"+"\n")
-        else:
-            with open("log.txt", "a") as file:
-                for e, t in zip(self.energies, self.temperatures):
-                    file.write(f"{e},{t}"+"\n")
+        if len(self.energies) != 0:
+            if not os.path.isfile("log.txt"):
+                with open("log.txt", "w") as file:
+                    for e, t in zip(self.energies, self.temperatures):
+                        file.write(f"{e},{t}"+"\n")
+            else:
+                with open("log.txt", "a") as file:
+                    for e, t in zip(self.energies, self.temperatures):
+                        file.write(f"{e},{t}"+"\n")
 
     def _load_system(self):
         return NotImplementedError

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -205,9 +205,9 @@ class Simulation:
         system_array = self.system_history[frame]
         np.savetxt(fname="system.txt", X=system_array)
 
-    def save_trajectory(self, fname="traj.gsd", start_frame=0, last_frame=-1):
+    def save_trajectory(self, fname="traj.gsd"):
         with gsd.hoomd.open(fname, 'wb') as traj:
-            for sys in self.system_history[start_frame:last_frame]:
+            for sys in self.system_history:
                 snap = gsd.hoomd.Snapshot()
                 snap.particles.N = self.n_particles
                 snap.configuration.box = [self.L, self.L, self.L, 0, 0, 0]

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
 dependencies: 
   - numpy
-  - gsd
   - matplotlib
   - jupyter
   - freud
   - numba=0.56.4
+  - gsd

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - matplotlib
   - jupyter
   - freud
-  - numba
+  - numba=0.56.4

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies: 
   - numpy
+  - gsd
   - matplotlib
   - jupyter
   - freud

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,6 @@
 name: advsamp
+channels:
+  - conda-forge
 dependencies: 
   - numpy
   - matplotlib


### PR DESCRIPTION
This PR moves temperature and max move size to the run function. This way we can use different values. For example, using a very high kT to get the system mixed up, or adjusting the max move size based on acceptance ratio or de correlation time.

This also adds functions to store system positions to a gsd file, and energies and temperatures to a txt file. This includes everything in #22, so I'll close that one.