### PR TITLE
Change job time from 96 to 48 h

### DIFF
--- a/MCMC/MCMC-flow/templates/borah.sh
+++ b/MCMC/MCMC-flow/templates/borah.sh
@@ -5,7 +5,7 @@
 {% if partition %}
 #SBATCH --partition={{ partition }}
 {% endif %}
-#SBATCH -t {{ 96|format_timedelta }}
+#SBATCH -t {{ 48|format_timedelta }}
 {% if job_output %}
 #SBATCH --output={{ job_output }}
 #SBATCH --error={{ job_output }}

--- a/MCMC/MCMC-flow/templates/r2.sh
+++ b/MCMC/MCMC-flow/templates/r2.sh
@@ -5,7 +5,7 @@
 {% if partition %}
 #SBATCH --partition={{ partition }}
 {% endif %}
-#SBATCH -t {{ 96|format_timedelta }}
+#SBATCH -t {{ 48|format_timedelta }}
 {% if job_output %}
 #SBATCH --output={{ job_output }}
 #SBATCH --error={{ job_output }}


### PR DESCRIPTION
The time limit for job submitted on Borah and R2 cluster with `short` partition is 48 hours.