### PR TITLE
Set default to overlapping

### DIFF
--- a/MCMC/MCMC-flow/init.py
+++ b/MCMC/MCMC-flow/init.py
@@ -25,7 +25,7 @@ def get_parameters():
     parameters["r"] = [0.5]
     parameters["r_cut"] = [2.5]
     parameters["energy_func"] = ["lj"]
-    parameters["hard_sphere"] = [True]
+    parameters["hard_sphere"] = [False]
 
     # LJ energy parameters
     parameters["epsilon"] = [1.0]

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -152,7 +152,10 @@ class Simulation:
             # Make move; get particle, original and new coordinates
             move_idx, original_coords, new_coords = self.trial_move(max_trans)
             self.system[move_idx] = new_coords
-            overlap = check_overlap(self.system, move_idx, self.L, self.r)
+            if self.hard_sphere:
+                overlap = check_overlap(self.system, move_idx, self.L, self.r)
+            else:
+                overlap = False
             trial_energy = self.calculate_energy(self.system, overlap)
             if np.isfinite(trial_energy):
                 delta_U = trial_energy - initial_energy


### PR DESCRIPTION
Changing the default setting to overlapping sphere where `hard_sphere=False`. 
Also, when the system is not hard sphere, there is no need to check overlap in every move. 