### PR TITLE
Update acceptance condition

### DIFF
--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -164,7 +164,7 @@ class Simulation:
                     self.accepted_moves += 1
                 else:
                     rand_num = random.uniform(0, 1)
-                    if np.exp(-delta_U / kT) <= rand_num:
+                    if np.exp(-delta_U / kT) >= rand_num:
                         # Move accepted; keep updated self.system
                         self.accepted_moves += 1
                     else:  # Move rejected; change self.system to prev state


### PR DESCRIPTION
This PR fixes the error in the trial move acceptance conditions. 
When delta_U is greater than zero, the condition for accepting the move should be:

`np.exp(-delta_U / kT) >= rand_num`

where `rand_num` is a random number between 0 and 1. 