### PR TITLE
Use the `set_default()` function to prevent job doc values from being overwritten

### DIFF
--- a/MCMC/MCMC-flow/init.py
+++ b/MCMC/MCMC-flow/init.py
@@ -57,6 +57,7 @@ def main():
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("timestep", [])
         parent_job.doc.setdefault("accepted_moves", [])
         parent_job.doc.setdefault("rejected_moves", [])
         parent_job.doc.setdefault("acceptance_ratio", [])

--- a/MCMC/MCMC-flow/init.py
+++ b/MCMC/MCMC-flow/init.py
@@ -57,6 +57,11 @@ def main():
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("accepted_moves", [])
+        parent_job.doc.setdefault("rejected_moves", [])
+        parent_job.doc.setdefault("acceptance_ratio", [])
+        parent_job.doc.setdefault("tps", [])
+        parent_job.doc.setdefault("energy", [])
         # each pair of (`n_steps`, `kT`) defines a phase of simulation run. The `phase_{i}` key in job doc determines
         # whether that phase is already done or not. False means phase is not done.
         n_steps_size = len(parent_statepoint['n_steps'])
@@ -69,12 +74,6 @@ def main():
             raise ValueError(
                 "These lists must have the same length: `n_steps`, `kT` and `max_trans` for each job! \n "
                 "`n_step` size: {}, `kT` size: {}, `max_trans` size: {}".format(n_steps_size, kT_size, max_trans_size))
-        parent_job.doc["timestep"] = []
-        parent_job.doc["accepted_moves"] = []
-        parent_job.doc["rejected_moves"] = []
-        parent_job.doc["acceptance_ratio"] = []
-        parent_job.doc["tps"] = []
-        parent_job.doc["energy"] = []
     if custom_job_doc:
         for key in custom_job_doc:
             parent_job.doc.setdefault(key, custom_job_doc[key])


### PR DESCRIPTION
The way `init.py` in `MCMC-flow` is currently designed causes job.doc values to be overwritten every time `init.py` is called. I believe we can use the `job.doc.set_default()` method here to prevent this. 

What happened is that when I initialized more jobs in a workspace that already had completed jobs, the job.doc values for things like acceptance ratio, tps, etc.. were overwritten in the jobs that were already finished.