### PR TITLE
Refactoring

### DIFF
--- a/MCMC/MCMC-flow/init.py
+++ b/MCMC/MCMC-flow/init.py
@@ -25,7 +25,7 @@ def get_parameters():
     parameters["r"] = [0.5]
     parameters["r_cut"] = [2.5]
     parameters["energy_func"] = ["lj"]
-    parameters["hard_sphere"] = [True]
+    parameters["hard_sphere"] = [False]
 
     # LJ energy parameters
     parameters["epsilon"] = [1.0]
@@ -35,14 +35,14 @@ def get_parameters():
 
     # logging parameters
     parameters["energy_write_freq"] = [1000]
-    parameters["trajectory_write_freq"] = [10000]
+    parameters["trajectory_write_freq"] = [1000]
 
     # run parameters
-    parameters["mixing_steps"] = [2000]
+    parameters["mixing_steps"] = [10e5]
     parameters["mixing_kT"] = [10]
     parameters["mixing_max_trans"] = [0.5]
 
-    parameters["n_steps"] = [[2000]]
+    parameters["n_steps"] = [[10e5]]
     parameters["kT"] = [[1.5]]
     parameters["max_trans"] = [[0.5]]
     parameters["seed"] = [20]

--- a/MCMC/MCMC-flow/init.py
+++ b/MCMC/MCMC-flow/init.py
@@ -38,9 +38,13 @@ def get_parameters():
     parameters["trajectory_write_freq"] = [10000]
 
     # run parameters
-    parameters["n_steps"] = [[1e7, 1e8]]
-    parameters["kT"] = [[10, 1.5]]
-    parameters["max_trans"] = [[3.0, 0.5]]
+    parameters["mixing_steps"] = [2000]
+    parameters["mixing_kT"] = [10]
+    parameters["mixing_max_trans"] = [0.5]
+
+    parameters["n_steps"] = [[2000]]
+    parameters["kT"] = [[1.5]]
+    parameters["max_trans"] = [[0.5]]
     parameters["seed"] = [20]
 
     return list(parameters.keys()), list(product(*parameters.values()))
@@ -58,24 +62,14 @@ def main():
         parent_job = project.open_job(parent_statepoint)
         parent_job.init()
         parent_job.doc.setdefault("done", False)
+        parent_job.doc.setdefault("current_run", 0)
+        parent_job.doc.setdefault("mixed", False)
         parent_job.doc.setdefault("timestep", [])
         parent_job.doc.setdefault("accepted_moves", [])
         parent_job.doc.setdefault("rejected_moves", [])
         parent_job.doc.setdefault("acceptance_ratio", [])
         parent_job.doc.setdefault("tps", [])
         parent_job.doc.setdefault("energy", [])
-        # each pair of (`n_steps`, `kT`) defines a phase of simulation run. The `phase_{i}` key in job doc determines
-        # whether that phase is already done or not. False means phase is not done.
-        n_steps_size = len(parent_statepoint['n_steps'])
-        kT_size = len(parent_statepoint['kT'])
-        max_trans_size = len(parent_statepoint['max_trans'])
-        if n_steps_size == kT_size == max_trans_size:
-            for i in range(1, n_steps_size + 1):
-                parent_job.doc.setdefault("phase_{}".format(i), False)
-        else:
-            raise ValueError(
-                "These lists must have the same length: `n_steps`, `kT` and `max_trans` for each job! \n "
-                "`n_step` size: {}, `kT` size: {}, `max_trans` size: {}".format(n_steps_size, kT_size, max_trans_size))
     if custom_job_doc:
         for key in custom_job_doc:
             parent_job.doc.setdefault(key, custom_job_doc[key])

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -53,7 +53,7 @@ class Simulation:
         self.energies = [copy.deepcopy(self.energy)]
         self.temperatures = []
         self._tps = []
-        
+
         random.seed(seed)
 
     @property
@@ -211,7 +211,7 @@ class Simulation:
             plt.savefig(os.path.join(save_path, fig_name))
         return plt
 
-    def save_snapshot(self,fname="restart.gsd"):
+    def save_snapshot(self, fname="restart.gsd"):
         """
         Save a snapshot of system to a .gsd file.
         :param fname: name of the file.

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -76,7 +76,7 @@ class Simulation:
         x and y coordinates are between -L/2 and L/2.
         :return: A 2D numpy array of shape (self.n_particles, 2).
         """
-        if restart and os.path.isfile("system.txt"):
+        if restart and os.path.isfile("restart.gsd"):
             system = self._load_system()
         else:
             disks_per_row = math.floor((self.L - self.r) / (2 * self.r))
@@ -211,13 +211,18 @@ class Simulation:
             plt.savefig(os.path.join(save_path, fig_name))
         return plt
 
-    def save_system(self, frame=-1):
+    def save_snapshot(self,fname="restart.gsd"):
         """
-        Save a single snapshot of system_history to a .txt file.
-        :param frame: Index number of system_history
+        Save a snapshot of system to a .gsd file.
+        :param fname: name of the file.
         """
-        system_array = self.system_history[frame]
-        np.savetxt(fname="system.txt", X=system_array)
+        with gsd.hoomd.open(fname, 'wb') as traj:
+            snap = gsd.hoomd.Snapshot()
+            snap.particles.N = self.n_particles
+            snap.configuration.box = [self.L, self.L, self.L, 0, 0, 0]
+            snap.particles.type = ['A']
+            snap.particles.position = np.append(self.system, np.zeros((self.system.shape[0], 1)), axis=1)
+            traj.append(snap)
 
     def save_trajectory(self, fname="traj.gsd"):
         with gsd.hoomd.open(fname, 'wb') as traj:
@@ -248,10 +253,18 @@ class Simulation:
                         file.write(f"{e},{t}" + "\n")
 
     def _load_system(self):
-        system = np.loadtxt(fname="system.txt")
+        snapshot = gsd.hoomd.open("restart.gsd")[0]
         try:
-            assert system.shape[0] == self.n_particles
+            assert snapshot.particles.N == self.n_particles
         except AssertionError:
             raise AssertionError(
                 "Number of particles in the saved system is not equal to the specified number of particles!")
-        return system
+
+        try:
+            assert snapshot.configuration.box[0] == self.L
+        except AssertionError:
+            raise AssertionError(
+                "Box size in the saved system is not equal to the box size!")
+
+        sys = snapshot.particles.position[:, :2]
+        return sys

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -261,10 +261,9 @@ class Simulation:
                 "Number of particles in the saved system is not equal to the specified number of particles!")
 
         try:
-            assert snapshot.configuration.box[0] == self.L
+            assert np.isclose(snapshot.configuration.box[0], self.L)
         except AssertionError:
             raise AssertionError(
                 "Box size in the saved system is not equal to the box size!")
-
         sys = snapshot.particles.position[:, :2]
         return sys

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -238,6 +238,7 @@ class Simulation:
         """Clear the system history and reset the system."""
         self.system_history.clear()
         self.energies.clear()
+        self.energies.clear()
         self.timestep = 0
         self.accepted_moves = 0
         self.rejected_moves = 0

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -22,7 +22,7 @@ class Simulation:
             trajectory_write_freq=10000,
             seed=20,
             energy_func=None,
-            hard_sphere=True,
+            hard_sphere=False,
             restart=False,
             **kwargs):
         """

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -237,6 +237,7 @@ class Simulation:
     def reset_system(self):
         """Clear the system history and reset the system."""
         self.system_history.clear()
+        self.energies.clear()
         self.timestep = 0
         self.accepted_moves = 0
         self.rejected_moves = 0

--- a/MCMC/utils.py
+++ b/MCMC/utils.py
@@ -74,7 +74,7 @@ def inverse_distance_repulsive(distances):
     return (1. / np.power(distances, 2)).sum()
 
 
-def lj_energy(distances, epsilon=1.0, sigma=1.0, n=12, m=6):
+def lj_energy(distances, epsilon=1.0, sigma=1.0, n=12, m=6, e_factor=1):
     """
     Calculates Lennard-Jones pair potential.
     :param distances: 1D array of distances.
@@ -82,9 +82,10 @@ def lj_energy(distances, epsilon=1.0, sigma=1.0, n=12, m=6):
     :param sigma: Particle size sigma.
     :param n: Repulsive power factor.
     :param m: Attractive power factor.
+    :param e_factor: epsilon coefficient.
     :return: Total energy.
     """
-    return 4 * epsilon * (np.power(sigma / distances, n) - np.power(sigma / distances, m)).sum()
+    return 4 * (e_factor* epsilon) * (np.power(sigma / distances, n) - np.power(sigma / distances, m)).sum()
 
 
 @jit(nopython=True)


### PR DESCRIPTION
This PR updates a couple of things:

- Separating mixing step from running steps in signac init. The reason for this change is to make it easier to repeat the run step during PT swaps.

- Saving a gsd snapshot at the end of run instead of saving a .txt file.
- Allow system to load from a snapshot if provided.