### PR TITLE
Make pip installable

### DIFF
--- a/MCMC/__init__.py
+++ b/MCMC/__init__.py
@@ -1,0 +1,1 @@
+from .simulation import Simulation

--- a/MCMC/__version__.py
+++ b/MCMC/__version__.py
@@ -1,0 +1,3 @@
+VERSION = (0, 0, 1)
+
+__version__ = ".".join(map(str, VERSION))

--- a/MCMC/simulation.py
+++ b/MCMC/simulation.py
@@ -8,7 +8,7 @@ import gsd.hoomd
 import matplotlib.pyplot as plt
 import numpy as np
 
-from utils import pair_distances, check_overlap
+from MCMC.utils import pair_distances, check_overlap
 
 
 class Simulation:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Example copied with love from:
+# https://github.com/kennethreitz/setup.py/blob/master/setup.py
+
+# Note: To use the 'upload' functionality of this file, you must:
+#   $ pip install twine
+
+import io
+import os
+import sys
+from shutil import rmtree
+
+from setuptools import find_packages, setup, Command
+
+# Package meta-data.
+NAME = 'MCMC'
+DESCRIPTION = 'Markov-Chain-Monte-Carlo engine implemented in python.'
+URL = '://github.com/cmelab/Advanced-Sampling'
+EMAIL = 'ericjankowski@boisestate.edu'
+AUTHOR = 'Chris Jones, Marjan Albooyeh, Gwen White, Madilyn Paul'
+REQUIRES_PYTHON = '>=3.9.0'
+VERSION = None
+
+# What packages are required for this module to be executed?
+REQUIRED = []
+
+# Follow the README and use the environment.yml file to install
+# the needed packages.
+# ------------------------------------------------
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# Load the package's __version__.py module as a dictionary.
+about = {}
+if not VERSION:
+    with open(os.path.join(here, NAME, '__version__.py')) as f:
+        exec(f.read(), about)
+else:
+    about['__version__'] = VERSION
+
+
+class UploadCommand(Command):
+    """Support setup.py upload."""
+
+    description = 'Build and publish the package.'
+    user_options = []
+
+    @staticmethod
+    def status(s):
+        """Prints things in bold."""
+        print('\033[1m{0}\033[0m'.format(s))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            self.status('Removing previous builds…')
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status('Building Source and Wheel (universal) distribution…')
+        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+
+        self.status('Uploading the package to PyPi via Twine…')
+        os.system('twine upload dist/*')
+
+        self.status('Pushing git tags…')
+        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git push --tags')
+
+        sys.exit()
+
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=about['__version__'],
+    description=DESCRIPTION,
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(exclude=('tests', 'docs',)),
+    # If your package is a single module, use this instead of 'packages':
+    # py_modules=['mypackage'],
+
+    # entry_points={
+    #     'console_scripts': ['mycli=mymodule:cli'],
+    # },
+    package_data={"MCMC": [
+        "simulation.py,"
+    ]},
+    install_requires=REQUIRED,
+    include_package_data=True,
+    license='GPL',
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+    # $ setup.py publish support.
+    cmdclass={
+        'upload': UploadCommand,
+    },
+)


### PR DESCRIPTION
This PR adds a `setup.py` file so that the MCMC package can be installed via pip.  This makes it easier to use in the parallel tempering workflow. 

I think at some point we should move `MCMC-flow` out of here and into its own repo as well, where it can import `MCMC`